### PR TITLE
add font family for Chinese

### DIFF
--- a/src/app/assets/stylesheets/foundation-settings.scss
+++ b/src/app/assets/stylesheets/foundation-settings.scss
@@ -50,7 +50,7 @@ $body-font-color: $black !default;
 
 /// Font stack of the body.
 /// @type List
-$body-font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif !default;
+$body-font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', SimSun, sans-serif !default;
 
 /// Global value used for all elements that have a border radius.
 /// @type Number

--- a/src/app/assets/stylesheets/markdown.scss
+++ b/src/app/assets/stylesheets/markdown.scss
@@ -1,5 +1,5 @@
 .Markdown {
-  font-family: 'Source Serif Pro', serif;
+  font-family: inherit;
   font-size: 120%;
 
   line-height: 150%;


### PR DESCRIPTION
1. 增加了一些中文字体
2. 文章正文原使用 `'Source Serif Pro', serif`，现改为与全局一致